### PR TITLE
Add flag for threading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ $(OUT_SIM)/$(PROJECT_NAME): sim/$(PROJECT_NAME).cpp obj_dir/V$(PROJECT_NAME)__AL
 		$(VINC)/verilated.cpp \
 		$(VINC)/verilated_vcd_c.cpp \
 		$(VINC)/verilated_threads.cpp \
-		sim/$(PROJECT_NAME).cpp obj_dir/V$(PROJECT_NAME)__ALL.a \
+		sim/$(PROJECT_NAME).cpp -lpthread obj_dir/V$(PROJECT_NAME)__ALL.a \
 		-o $(OUT_SIM)/$(PROJECT_NAME)
 
 $(OUT_SIM)/$(PROJECT_NAME).vcd: $(OUT_SIM)/$(PROJECT_NAME)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SEED = 1
 ARCHIVE=oss-cad-suite.tgz
 OSS_CAD_SUITE = oss-cad-suite
 VINC := $(OSS_CAD_SUITE)/share/verilator/include
-OSS_CAD_SUITE_URL=https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2023-10-17/oss-cad-suite-linux-x64-20231017.tgz
+OSS_CAD_SUITE_URL=https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2023-10-31/oss-cad-suite-linux-x64-20231031.tgz
 
 # List of all Directories (useful for initalization)
 DIRS = $(OUT) $(OUT_SIM) $(ARTIFACTS) $(LOGS) $(STATS_DIR)


### PR DESCRIPTION
Running the `make buildsim` resulted in the following threading message:

```
/usr/bin/ld: /tmp/ccRNZqqC.o: in function `std::thread::thread<void (VerilatedTrace<VerilatedVcd, VerilatedVcdBuffer>::*)(), VerilatedTrace<VerilatedVcd, VerilatedVcdBuffer>*, void>(void (VerilatedTrace<VerilatedVcd, VerilatedVcdBuffer>::*&&)(), VerilatedTrace<VerilatedVcd, VerilatedVcdBuffer>*&&)':
verilated_vcd_c.cpp:(.text._ZNSt6threadC2IM14VerilatedTraceI12VerilatedVcd18VerilatedVcdBufferEFvvEJPS4_EvEEOT_DpOT0_[_ZNSt6threadC5IM14VerilatedTraceI12VerilatedVcd18VerilatedVcdBufferEFvvEJPS4_EvEEOT_DpOT0_]+0x24): undefined reference to `pthread_create'
/usr/bin/ld: /tmp/ccb1M4nB.o: in function `std::thread::thread<void (&)(VlWorkerThread*, VerilatedContext*), VlWorkerThread*, VerilatedContext*&, void>(void (&)(VlWorkerThread*, VerilatedContext*), VlWorkerThread*&&, VerilatedContext*&)':
verilated_threads.cpp:(.text._ZNSt6threadC2IRFvP14VlWorkerThreadP16VerilatedContextEJS2_RS4_EvEEOT_DpOT0_[_ZNSt6threadC5IRFvP14VlWorkerThreadP16VerilatedContextEJS2_RS4_EvEEOT_DpOT0_]+0x2a): undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
make: *** [Makefile:60: sim_build/test_name] Error 1
```

This error was resolved by adding the -lpthread flag to the g++ invocation after the cpp file name specification.